### PR TITLE
Fix deprecation warnings when running manage.py

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -2,7 +2,7 @@ Flask>=0.11.0
 
 # Flask Extensions
 Flask-Assets
-Flask-Cache
+Flask-Caching
 Flask-DebugToolbar
 # Flask-Login
 Flask-SQLAlchemy
@@ -11,6 +11,7 @@ Flask-WTF
 Flask-Security
 Flask-Bootstrap
 Flask-OAuthlib
+Flask-Migrate
 
 # Social required
 facebook-sdk

--- a/shell/webinterface/extensions.py
+++ b/shell/webinterface/extensions.py
@@ -1,5 +1,5 @@
 from flask_bootstrap import Bootstrap
-from flask_cache import Cache
+from flask_caching import Cache
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_security import Security
 from flask_assets import Environment

--- a/shell/webinterface/settings.py
+++ b/shell/webinterface/settings.py
@@ -14,6 +14,7 @@ class DevConfig(Config):
 
     SQLALCHEMY_DATABASE_URI = 'sqlite:///../database.db'
     SQLALCHEMY_ECHO = False
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     CACHE_TYPE = 'simple'
 
@@ -38,12 +39,12 @@ class DevConfig(Config):
     SECURITY_CONFIRMABLE = False
     #SECURITY_CHANGE_URL = '/change_password'
     #SECURITY_SEND_PASSWORD_CHANGE_EMAIL = False
-    
+
     SOCIAL_TWITTER = {
         'consumer_key': 'twitter consumer key',
         'consumer_secret': 'twitter consumer secret'
     }
-    
+
     SOCIAL_FACEBOOK = {
         'consumer_key': 'twitter consumer key',
         'consumer_secret': 'twitter consumer secret'


### PR DESCRIPTION
Switch to flask caching because flask cache project
was abandonded. Disable sqlalchemy track modifications
since it's not in use.
